### PR TITLE
snippets for Test::Unit 2.2.0 assertions

### DIFF
--- a/ruby/asam.snippet
+++ b/ruby/asam.snippet
@@ -1,0 +1,1 @@
+assert_alias_method ${1:object}, ${2:alias_name}, ${3:original_name}

--- a/ruby/asb.snippet
+++ b/ruby/asb.snippet
@@ -1,0 +1,1 @@
+assert_boolean ${1:actual}

--- a/ruby/asc.snippet
+++ b/ruby/asc.snippet
@@ -1,0 +1,1 @@
+assert_compare ${1:expected}, ${2:operator}, ${3:actual}

--- a/ruby/ascd.snippet
+++ b/ruby/ascd.snippet
@@ -1,0 +1,1 @@
+assert_const_defined ${1:object}, ${2:constant_name}

--- a/ruby/asem.snippet
+++ b/ruby/asem.snippet
@@ -1,0 +1,1 @@
+assert_empty ${1:object}

--- a/ruby/asf.snippet
+++ b/ruby/asf.snippet
@@ -1,0 +1,1 @@
+assert_false ${1:actual}

--- a/ruby/asfa.snippet
+++ b/ruby/asfa.snippet
@@ -1,0 +1,1 @@
+assert_fail_assertion { ${1:block} }

--- a/ruby/asi.snippet
+++ b/ruby/asi.snippet
@@ -1,0 +1,1 @@
+assert_include ${1:collection}, ${2:object}

--- a/ruby/asie.snippet
+++ b/ruby/asie.snippet
@@ -1,0 +1,1 @@
+assert_in_epsilon ${1:expected_float}, ${2:actual_float}

--- a/ruby/asncd.snippet
+++ b/ruby/asncd.snippet
@@ -1,0 +1,1 @@
+assert_not_const_defined ${1:object}, ${2:constant_name}

--- a/ruby/asnem.snippet
+++ b/ruby/asnem.snippet
@@ -1,0 +1,1 @@
+assert_not_empty ${1:object}

--- a/ruby/asni.snippet
+++ b/ruby/asni.snippet
@@ -1,0 +1,1 @@
+assert_not_include ${1:collection}, ${2:object}

--- a/ruby/asnid.snippet
+++ b/ruby/asnid.snippet
@@ -1,0 +1,1 @@
+assert_not_in_delta ${1:expected_float}, ${2:actual_float}

--- a/ruby/asnie.snippet
+++ b/ruby/asnie.snippet
@@ -1,0 +1,1 @@
+assert_not_in_epsilon ${1:expected_float}, ${2:actual_float}

--- a/ruby/asnp.snippet
+++ b/ruby/asnp.snippet
@@ -1,0 +1,1 @@
+assert_not_predicate ${1:object}, ${2:predicate}

--- a/ruby/asnr.snippet
+++ b/ruby/asnr.snippet
@@ -1,0 +1,1 @@
+assert_nothing_raised { ${1:block} }

--- a/ruby/asnrt.snippet
+++ b/ruby/asnrt.snippet
@@ -1,0 +1,1 @@
+assert_not_respond_to ${1:object}, ${2:method}

--- a/ruby/asnse.snippet
+++ b/ruby/asnse.snippet
@@ -1,0 +1,1 @@
+assert_not_send ${1:send_array}

--- a/ruby/asp.snippet
+++ b/ruby/asp.snippet
@@ -1,0 +1,1 @@
+assert_predicate ${1:object}, ${2:predicate}

--- a/ruby/aspe.snippet
+++ b/ruby/aspe.snippet
@@ -1,0 +1,1 @@
+assert_path_exist ${1:path}

--- a/ruby/aspne.snippet
+++ b/ruby/aspne.snippet
@@ -1,0 +1,1 @@
+assert_path_not_exist ${1:path}

--- a/ruby/asrko.snippet
+++ b/ruby/asrko.snippet
@@ -1,0 +1,1 @@
+assert_raise_kind_of(${1:kinds...}) { ${2:block} }

--- a/ruby/asrm.snippet
+++ b/ruby/asrm.snippet
@@ -1,0 +1,1 @@
+assert_raise_message ${1:expected_message}

--- a/ruby/asse.snippet
+++ b/ruby/asse.snippet
@@ -1,0 +1,1 @@
+assert_send ${1:send_array}

--- a/ruby/astr.snippet
+++ b/ruby/astr.snippet
@@ -1,0 +1,1 @@
+assert_true ${1:actual}


### PR DESCRIPTION
Added a bunch of missing assertion snippets; full list is here:
http://rubydoc.info/gems/test-unit/2.2.0/Test/Unit/Assertions
