### PR TITLE
Using single backquotes for Snippet_PythonClassNameFromFilename() call in python/class.snippet

### DIFF
--- a/python/class.snippet
+++ b/python/class.snippet
@@ -1,2 +1,2 @@
-class ${1:``Snippet_PythonClassNameFromFilename()``}(${2:data}):
+class ${1:`Snippet_PythonClassNameFromFilename()`}(${2:data}):
 ${3}


### PR DESCRIPTION
The python class autocompletion wouldn't work with double backquotes.
