### PR TITLE
search for bundle/snipmat.vim/snippets as a snippets dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,13 @@
 namespace :snippets_dir do
   task :find do
     vim_dir = File.join(ENV['VIMFILES'] || ENV['HOME'] || ENV['USERPROFILE'], RUBY_PLATFORM =~ /mswin|msys|mingw32/ ? "vimfiles" : ".vim")
-    pathogen_dir = File.join(vim_dir, "bundle")
-    @snippets_dir = File.directory?(pathogen_dir) ? File.join(pathogen_dir, "snipmate", "snippets") : File.join(vim_dir, "snippets")
+    possible_dirs = [
+      File.join(vim_dir, 'snippets'),
+      File.join(vim_dir, 'bundle', 'snipmate', 'snippets'),
+      File.join(vim_dir, 'bundle', 'snipmate.vim', 'snippets')
+    ]
+
+    @snippets_dir = possible_dirs.find{ |dir| File.directory? dir }
   end
 
   desc "Purge the contents of the vim snippets directory"


### PR DESCRIPTION
Hey Martin,

I'm using vundle (https://github.com/gmarik/vundle) to manage vim scripts. It has a short syntax for scripts hosted on github, like 

Bundle 'msanders/snipmate.vim'
Bundle 'scrooloose/snipmate-snippets'
Bundle 'scrooloose/nerdtree'
Bundle 'vim-scripts/NERD_Tree-and-ack'

there is the last part of the url https://github.com/msanders/snipmate.vim in the config.
And it installs the snipmate into the bundle/snipmate.vim directory.

I've change the rake task to search for that directory as well as .vim/snipmate and bundle/snipmate

Thanks,
Alex
