### PR TITLE
Fix for Python "class" snippet

### DIFF
--- a/python/class.snippet
+++ b/python/class.snippet
@@ -1,2 +1,2 @@
-class ${1:``Snippet_PythonClassNameFromFilename()``}(${2:data}):
+class ${1:`Snippet_PythonClassNameFromFilename()`}(${2:data}):
 ${3}


### PR DESCRIPTION
Removed extra graves that caused class<tab> to crash when editing Python files.
