### PR TITLE
When snipmate is installed using Vundle instead of Pathogen the path to snipmate is different.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ namespace :snippets_dir do
   task :find do
     vim_dir = File.join(ENV['VIMFILES'] || ENV['HOME'] || ENV['USERPROFILE'], RUBY_PLATFORM =~ /mswin|msys|mingw32/ ? "vimfiles" : ".vim")
     pathogen_dir = File.join(vim_dir, "bundle")
-    @snippets_dir = File.directory?(pathogen_dir) ? File.join(pathogen_dir, "snipmate", "snippets") : File.join(vim_dir, "snippets")
+    @snippets_dir = [File.join(pathogen_dir, 'snipmate', 'snippets'), File.join(pathogen_dir, 'snipmate.vim', 'snippets'), File.join(vim_dir, "snippets")].select do | folder |
+      File.exists? folder
+    end[0]
   end
 
   desc "Purge the contents of the vim snippets directory"

--- a/javascript/for.snippet
+++ b/javascript/for.snippet
@@ -1,3 +1,3 @@
-for (var <+i+>=0; <+i+> < <+<+Things+>.length+>; <+i+>++) {
-<+<+Things+>[<+i+>]+>
-};
+for (var ${1:i}=0; ${1:i} < ${2:collection}.length; ${1:i}++) {
+	${2:collection}[${1:i}]
+}


### PR DESCRIPTION
This commit will look in each given path (pathogen, vundle, root), the first which exists sets @snippets_dir. 

It will also allow for additional paths to be added in the future should some other package manager install snipmate elsewhere.
